### PR TITLE
Fix for honouring Storage Cluster name during VM provisioning

### DIFF
--- a/vsphere/resource_vsphere_virtual_machine.go
+++ b/vsphere/resource_vsphere_virtual_machine.go
@@ -1626,13 +1626,13 @@ func buildStoragePlacementSpecClone(c *govmomi.Client, f *object.DatacenterFolde
 		},
 		CloneSpec: &types.VirtualMachineCloneSpec{
 			Location: types.VirtualMachineRelocateSpec{
-				Disk: []types.VirtualMachineRelocateSpecDiskLocator{
+				/*Disk: []types.VirtualMachineRelocateSpecDiskLocator{
 					{
 						Datastore:       ds.Reference(),
 						DiskBackingInfo: &types.VirtualDiskFlatVer2BackingInfo{},
 						DiskId:          key,
 					},
-				},
+				},*/
 				Pool: &rpr,
 			},
 			PowerOn:  false,


### PR DESCRIPTION
Do not populate the source disk details in spec when creating StoragePlacementSpec