### PR TITLE
Issue #3 : Hot changes to VM attributes CPU/Memory not supported

### DIFF
--- a/vsphere/resource_vsphere_virtual_machine.go
+++ b/vsphere/resource_vsphere_virtual_machine.go
@@ -486,18 +486,6 @@ func resourceVSphereVirtualMachineUpdate(d *schema.ResourceData, meta interface{
 	// make config spec
 	configSpec := types.VirtualMachineConfigSpec{}
 
-	if d.HasChange("vcpu") {
-		configSpec.NumCPUs = int32(d.Get("vcpu").(int))
-		hasChanges = true
-		rebootRequired = true
-	}
-
-	if d.HasChange("memory") {
-		configSpec.MemoryMB = int64(d.Get("memory").(int))
-		hasChanges = true
-		rebootRequired = true
-	}
-
 	client := meta.(*govmomi.Client)
 	dc, err := getDatacenter(client, d.Get("datacenter").(string))
 	if err != nil {
@@ -510,6 +498,53 @@ func resourceVSphereVirtualMachineUpdate(d *schema.ResourceData, meta interface{
 	if err != nil {
 		return err
 	}
+
+        // Read the VM properties (memory and cpu hot add properties)
+        var mov mo.VirtualMachine
+        collector := property.DefaultCollector(client.Client)
+        if err := collector.RetrieveOne(context.TODO(), vm.Reference(), []string{"summary", "config"}, &mov); err != nil {
+                return err
+        }
+
+        hasCpuHotAddEnabled := *mov.Config.CpuHotAddEnabled
+        hasCpuHotRemoveEnabled := *mov.Config.CpuHotRemoveEnabled
+        hasMemoryHotAddEnabled := *mov.Config.MemoryHotAddEnabled
+
+        // Handle CPU Hot Plug Feature
+        if d.HasChange("vcpu") {
+
+                newCPUsCount := int32(d.Get("vcpu").(int))
+                oldCPUsCount := mov.Summary.Config.NumCpu
+
+                configSpec.NumCPUs = newCPUsCount
+                hasChanges = true
+
+                if newCPUsCount < oldCPUsCount {
+                         if hasCpuHotRemoveEnabled == false {
+                                rebootRequired = true
+                         }
+                } else if hasCpuHotAddEnabled == false {
+                         rebootRequired = true
+                }
+        }
+
+        // Handle Memory Hot Add Feature
+        if d.HasChange("memory") {
+
+                newMemoryMB := int64(d.Get("memory").(int))
+                oldMemoryMB := int64(mov.Summary.Config.MemorySizeMB)
+
+                configSpec.MemoryMB = newMemoryMB
+                hasChanges = true
+
+                if hasMemoryHotAddEnabled == false {
+                       rebootRequired = true
+                } else if newMemoryMB < oldMemoryMB {
+                       rebootRequired = true
+                }
+
+        }
+
 
 	if d.HasChange("disk") {
 		hasChanges = true


### PR DESCRIPTION
Memory Hot Add Fix
------------------
The terraform vsphere provider has been changed to incorporte code for checking "memory hot add (MemoryHotAddEnabled)" flag before taking reboot decision.
- If "memory hot add (MemoryHotAddEnabled)" is set to true, then we do not reboot the VM.
- If "memory hot add (MemoryHotAddEnabled)" is set to false, then we reboot(power off-->apply changes-->power on) the VM.

And memory change (reduce) operation always need VM reboot(power off-->apply changes-->power on).

CPU Hot Plug Fix
----------------
The terraform vsphere provider has been changed to incorporte code for checking "cpu hot add (CpuHotAddEnabled)" flag and "cpu hot remove (CpuHotRemoveEnabled)" flag before taking reboot decision.
- If "cpu hot add (CpuHotAddEnabled)" and "cpu hot remove (CpuHotRemoveEnabled)" is set to true, then we do not reboot the VM.
- If "cpu hot add (CpuHotAddEnabled)" and "cpu hot remove (CpuHotRemoveEnabled)" is set to false, then we reboot(power off-->apply changes-->power on) the VM.